### PR TITLE
fix autoclosure capture issue

### DIFF
--- a/Tests/FutureTests/Inout.swift
+++ b/Tests/FutureTests/Inout.swift
@@ -17,11 +17,13 @@ final class FutureInoutTests: XCTestCase {
     var x = 0
     let y = Inout(&x)
 
-    XCTAssertEqual(y[], 0)
+    var v = y[]
+    XCTAssertEqual(v, 0)
 
     y[] += 10
 
-    XCTAssertEqual(y[], 10)
+    v = y[]
+    XCTAssertEqual(v, 10)
     XCTAssertEqual(x, 10)
   }
 }


### PR DESCRIPTION
Fix autoclosure-related issues. Captures by autoclosures are (sometimes) misdiagnosed as escapes; this happened here.